### PR TITLE
Gemfile: Remove rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,5 @@ gem 'highline'
 group :test do
 	gem 'rspec'
 	gem 'mocha'
-	gem 'rake'
 	gem 'coveralls', require: false
 end


### PR DESCRIPTION
because it's already in the gemspec

Should prevent warnings like:

```
Your Gemfile lists the gem rake (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
```